### PR TITLE
normalize user-provided credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-v2",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-v2",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An asynchronous client library for the Twitter REST and Streaming V2 API's.",
   "main": "src/twitter.js",
   "scripts": {

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -121,7 +121,14 @@ module.exports = class Credentials {
 
     this._consumer_key = consumer_key;
     this._consumer_secret = consumer_secret;
-    this._bearer_token = bearer_token;
+    // Reasonably, some clients provide the authorization header as the bearer
+    // token, in this case we automatically strip the bearer prefix to normalize
+    // the credentials.
+    //
+    // https://github.com/HunterLarco/twitter-v2/issues/32
+    this._bearer_token = bearer_token.startsWith('Bearer ')
+      ? bearer_token.substr(7)
+      : bearer_token;
     this._access_token_key = access_token_key;
     this._access_token_secret = access_token_secret;
 


### PR DESCRIPTION
As per #32 some clients are passing in the authorization header as a bearer token. In this case, strip the Bearer prefix so that further authorization is successful.