### PR TITLE
app-auth credentials accept just a bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,21 @@ const client = new Twitter({
 ## For app based authentication:
 
 Alternatively, app authentication (which can only access public data but is
-often suitable for server applications) only needs your app's consumer keys.
+often suitable for server applications) only needs your app's consumer keys
+and/or bearer token.
 
 ```javascript
 const client = new Twitter({
   consumer_key: '',
   consumer_secret: '',
+});
+```
+
+or
+
+```javascript
+const client = new Twitter({
+  bearer_token: '',
 });
 ```
 

--- a/examples/helpers/credentials.js
+++ b/examples/helpers/credentials.js
@@ -23,15 +23,17 @@ module.exports.fromCommandLine = async () => {
   };
 
   const prompts = [];
-  if (!credentials.consumer_key) {
+  if (
+    !credentials.consumer_key &&
+    !credentials.consumer_secret &&
+    !credentials.bearer_token
+  ) {
     prompts.push({
       type: 'input',
       name: 'consumer_key',
       message: `consumer-key:`,
       validate: enquirerNotEmptyValidation,
     });
-  }
-  if (!credentials.consumer_secret) {
     prompts.push({
       type: 'input',
       name: 'consumer_secret',
@@ -55,8 +57,8 @@ module.exports.fromCommandLine = async () => {
     );
     console.log(
       chalk.dim(
-        'Note that you can use --consumer-key and --consumer-secret to ' +
-          'preemptively satisfy these prompts'
+        'Note that you can use --consumer-key and --consumer-secret or ' +
+          '--bearer-token to preemptively satisfy these prompts'
       )
     );
   }

--- a/src/Credentials.d.ts
+++ b/src/Credentials.d.ts
@@ -1,7 +1,16 @@
-export interface ApplicationCredentials {
+export interface ApplicationConsumerCredentials {
   consumer_key: string;
   consumer_secret: string;
-  bearer_token?: string;
+}
+
+export interface ApplicationBearerCredentials {
+  bearer_token: string;
+}
+
+export interface ApplicationFullCredentials {
+  consumer_key: string;
+  consumer_secret: string;
+  bearer_token: string;
 }
 
 export interface UserCredentials {
@@ -11,7 +20,11 @@ export interface UserCredentials {
   access_token_secret: string;
 }
 
-export type CredentialsArgs = ApplicationCredentials | UserCredentials;
+export type CredentialsArgs =
+  | ApplicationConsumerCredentials
+  | ApplicationBearerCredentials
+  | ApplicationFullCredentials
+  | UserCredentials;
 
 export class Credentials implements ApplicationCredentials, UserCredentials {
   constructor(args: CredentialsArgs);

--- a/test/Credentials.js
+++ b/test/Credentials.js
@@ -3,17 +3,39 @@ const { expect } = require('chai');
 const Credentials = require('../src/Credentials.js');
 
 describe('Credentials', () => {
-  it('should require a consumer key and secret', () => {
+  it('should enforce that credentials are defined', () => {
     expect(() => new Credentials({})).to.throw(
-      'Missing required argument: consumer_key'
+      'Invalid argument: no credentials defined'
     );
+  });
 
-    expect(() => new Credentials({ consumer_key: 'foo' })).to.throw(
-      'Missing required argument: consumer_secret'
+  it('should enforce consumer key and secret parity', () => {
+    expect(
+      () =>
+        new Credentials({
+          consumer_key: 'foo',
+        })
+    ).to.throw(
+      'Invalid argument: when using consumer keys, both consumer_key and ' +
+        'consumer_secret must be defined'
     );
 
     expect(
-      () => new Credentials({ consumer_key: 'foo', consumer_secret: 'bar' })
+      () =>
+        new Credentials({
+          consumer_secret: 'bar',
+        })
+    ).to.throw(
+      'Invalid argument: when using consumer keys, both consumer_key and ' +
+        'consumer_secret must be defined'
+    );
+
+    expect(
+      () =>
+        new Credentials({
+          consumer_key: 'foo',
+          consumer_secret: 'bar',
+        })
     ).to.not.throw();
   });
 
@@ -64,15 +86,47 @@ describe('Credentials', () => {
           access_token_secret: 'quz',
         })
     ).to.throw(
-      'Invalid argument: access_token_key and access_token_secret should not ' +
-        'be used with bearer_token'
+      'Invalid argument: access_token_key and access_token_secret cannot be ' +
+        'used with bearer_token'
     );
+  });
+
+  it('should accept either consumer keys or bearer token for app auth', () => {
+    expect(
+      () =>
+        new Credentials({
+          consumer_key: 'foo',
+          consumer_secret: 'bar',
+        })
+    ).to.not.throw();
+
+    expect(
+      () =>
+        new Credentials({
+          bearer_token: 'baz',
+        })
+    ).to.not.throw();
+
+    expect(
+      () =>
+        new Credentials({
+          consumer_key: 'foo',
+          consumer_secret: 'bar',
+          bearer_token: 'baz',
+        })
+    ).to.not.throw();
   });
 
   it('should recognize app vs user auth', () => {
     let credentials = new Credentials({
       consumer_key: 'foo',
       consumer_secret: 'bar',
+    });
+    expect(credentials.appAuth()).to.be.true;
+    expect(credentials.userAuth()).to.be.false;
+
+    credentials = new Credentials({
+      bearer_token: 'foo',
     });
     expect(credentials.appAuth()).to.be.true;
     expect(credentials.userAuth()).to.be.false;


### PR DESCRIPTION
As per the [Twitter App-only Documentation](https://developer.twitter.com/en/docs/authentication/oauth-2-0/application-only)

> You can do application-only authentication using your apps consumer API keys, or by using a Bearer Token.

Previously we always required a set of consumer keys (see #47)