### PR TITLE
Return connection alive signal with iterator

### DIFF
--- a/src/TwitterStream.js
+++ b/src/TwitterStream.js
@@ -44,7 +44,8 @@ class TwitterStream {
           const response = await this._connect();
           response.body.pipe(split()).on('data', (line) => {
             if (!line.trim()) {
-              return;
+                this._emit(Promise.resolve({ done: false, value: null }));
+                return;
             }
 
             if (line == 'Rate limit exceeded') {


### PR DESCRIPTION
This is a quick fix for #48. It implies that users might need to check if an iterator data chunk is null before further processing. But it allows handling disconnects as the user can expect a return value every 20 seconds. (This is how I use it for now, no offense taken if you reject the pr to keep the iterator clean and do this somehow differently.)