### PR TITLE
added wait stream param

### DIFF
--- a/src/TwitterStream.d.ts
+++ b/src/TwitterStream.d.ts
@@ -1,5 +1,15 @@
+export interface StreamOptions {
+  // Number of seconds to wait for data or a heartbeat ping from Twitter before
+  // considering the stream closed (default value is 30 seconds).
+  timeout: number | undefined;
+}
+
 export class TwitterStream<T> implements AsyncIterable<T> {
-  constructor(connect: () => Promise<any>, close: () => void, options: object);
+  constructor(
+    connect: () => Promise<any>,
+    close: () => void,
+    options: StreamOptions
+  );
 
   [Symbol.asyncIterator](): AsyncIterator<T>;
 

--- a/src/TwitterStream.d.ts
+++ b/src/TwitterStream.d.ts
@@ -1,5 +1,5 @@
 export class TwitterStream<T> implements AsyncIterable<T> {
-  constructor(connect: () => Promise<any>, close: () => void);
+  constructor(connect: () => Promise<any>, close: () => void, options: object);
 
   [Symbol.asyncIterator](): AsyncIterator<T>;
 

--- a/src/TwitterStream.js
+++ b/src/TwitterStream.js
@@ -19,7 +19,7 @@ class DeferredPromise {
 
 class TwitterStream {
   constructor(connect, close, options) {
-    const { timeout = 20000 } = options;
+    const { timeout = 30000 } = options;
 
     this._connect = connect;
     this._close = close;

--- a/src/TwitterStream.js
+++ b/src/TwitterStream.js
@@ -18,14 +18,16 @@ class DeferredPromise {
 }
 
 class TwitterStream {
-  constructor(connect, close, wait) {
+  constructor(connect, close, options) {
+    const { timeout = 20000 } = options;
+
     this._connect = connect;
     this._close = close;
 
     this._state = State.NOT_STARTED;
     this._events = [new DeferredPromise()];
     this._timeout = null;
-    this._wait = wait || 20000;
+    this._wait = timeout;
   }
 
   _emit(promise) {

--- a/src/TwitterStream.js
+++ b/src/TwitterStream.js
@@ -18,13 +18,14 @@ class DeferredPromise {
 }
 
 class TwitterStream {
-  constructor(connect, close) {
+  constructor(connect, close, wait) {
     this._connect = connect;
     this._close = close;
 
     this._state = State.NOT_STARTED;
     this._events = [new DeferredPromise()];
     this._timeout = null;
+    this._wait = wait || 20000;
   }
 
   _emit(promise) {
@@ -45,7 +46,7 @@ class TwitterStream {
       clearTimeout(this._timeout);
       this._timeout = setTimeout(() => {
         this._closeWithError(new TwitterError('Stream unresponsive'));
-      }, 20000);
+      }, this._wait);
     }
   }
 

--- a/src/TwitterStream.js
+++ b/src/TwitterStream.js
@@ -19,7 +19,7 @@ class DeferredPromise {
 
 class TwitterStream {
   constructor(connect, close, options) {
-    const { timeout = 30000 } = options;
+    const { timeout = 30 } = options;
 
     this._connect = connect;
     this._close = close;
@@ -27,7 +27,7 @@ class TwitterStream {
     this._state = State.NOT_STARTED;
     this._events = [new DeferredPromise()];
     this._timeout = null;
-    this._wait = timeout;
+    this._wait = timeout * 1000;
   }
 
   _emit(promise) {

--- a/src/twitter.d.ts
+++ b/src/twitter.d.ts
@@ -27,7 +27,8 @@ declare module 'twitter-v2' {
 
     public stream<T extends any>(
       endpoint: string,
-      parameters?: RequestParameters
+      parameters?: RequestParameters,
+      options?: object
     ): TwitterStream<T>;
   }
 }

--- a/src/twitter.d.ts
+++ b/src/twitter.d.ts
@@ -6,12 +6,6 @@ declare module 'twitter-v2' {
     [key: string]: string | Array<string> | RequestParameters;
   }
 
-  export interface StreamOptions {
-    // Number of seconds to wait for data or a heartbeat ping from Twitter before
-    // considering the stream closed (default value is 30 seconds).
-    timeout: number | undefined;
-  }
-
   export default class Twitter {
     constructor(credentials: CredentialsArgs);
 

--- a/src/twitter.d.ts
+++ b/src/twitter.d.ts
@@ -1,9 +1,15 @@
 import { CredentialsArgs } from './Credentials';
-import { TwitterStream } from './TwitterStream';
+import { StreamOptions, TwitterStream } from './TwitterStream';
 
 declare module 'twitter-v2' {
   export interface RequestParameters {
     [key: string]: string | Array<string> | RequestParameters;
+  }
+
+  export interface StreamOptions {
+    // Number of seconds to wait for data or a heartbeat ping from Twitter before
+    // considering the stream closed (default value is 30 seconds).
+    timeout: number | undefined;
   }
 
   export default class Twitter {
@@ -28,7 +34,7 @@ declare module 'twitter-v2' {
     public stream<T extends any>(
       endpoint: string,
       parameters?: RequestParameters,
-      options?: object
+      options?: StreamOptions
     ): TwitterStream<T>;
   }
 }

--- a/src/twitter.js
+++ b/src/twitter.js
@@ -91,7 +91,7 @@ class Twitter {
     return json;
   }
 
-  stream(endpoint, parameters) {
+  stream(endpoint, parameters, wait) {
     const abortController = new AbortController();
 
     return new TwitterStream(
@@ -108,7 +108,8 @@ class Twitter {
       },
       () => {
         abortController.abort();
-      }
+      },
+      wait
     );
   }
 }

--- a/src/twitter.js
+++ b/src/twitter.js
@@ -91,7 +91,7 @@ class Twitter {
     return json;
   }
 
-  stream(endpoint, parameters, wait) {
+  stream(endpoint, parameters, options) {
     const abortController = new AbortController();
 
     return new TwitterStream(
@@ -109,7 +109,7 @@ class Twitter {
       () => {
         abortController.abort();
       },
-      wait
+      options || {}
     );
   }
 }


### PR DESCRIPTION
Description of the Change
Added configurable timeout value to compensate probable lag or latency between the Twitter stream host and client that may vary depending on the client's circumstance/s e.g. location.


Is this change addressing any open issues?
No.

Is this change backwards compatible for existing users?
Yes.

Does this change require additional Twitter API knowledge?
No.