### PR TITLE
removed parameter "body" in authorization header in post() method to fix OAuth1.0a authorization error 

### DIFF
--- a/build/twitter.js
+++ b/build/twitter.js
@@ -55,7 +55,6 @@ class Twitter {
                 'Content-Type': 'application/json',
                 Authorization: await this.credentials.authorizationHeader(url, {
                     method: 'POST',
-                    body: body,
                 }),
             },
             body: JSON.stringify(body || {}),

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -76,7 +76,6 @@ export default class Twitter {
         'Content-Type': 'application/json',
         Authorization: await this.credentials.authorizationHeader(url, {
           method: 'POST',
-          body: body,
         }),
       },
       body: JSON.stringify(body || {}),


### PR DESCRIPTION
When you use `post()` method with oauth1.0a user context authorization, you should get error response "Unauthorized".  
Indeed "Unauthorized" error problem like issue #39 has solved with PR #44, but it may be only case that is authorized with bearer token.  
The post request path shown in issue #39 demands only bearer token, but not user context authentication.  
https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/post-tweets-search-stream-rules

Some post request path need OAuth1.0a user context authentication, so current code doesn't work well when you use other post request path.
A purpose of this PR is just fix it.

It is seemed that caused by embeded `body` in the generating authorization header method.  
I've read the twitter API documentation and it doesn't seem to say that this is required.  
But twitter oauth library demands request data because of generating oauth signature.  

I think the reason why current code doesn't work well is Twitter API specification change between v1.1 and v2 described as above.  
In API v1.1, most of the post request parameters are sent as query parameters.  
But, in API v2, some of the post request parameters are sent as JSON body. And it is sent with `'Content-Type': 'application/json'` in current code.   
According to OAuth1.0a specification,request parameters can be "signature base string" when content type is `application/x-www-form-urlencoded`. 
but if it's other content type,it is not specified.   
https://oauth.net/core/1.0a/#anchor13  
(I'm sorry if I'm just not reading it properly)  



That's why I commited just 1 line code.

Here's temporary test code what I've prepared for this job.  
Current code fails following test code.(returned Unauthorized Error by API)  
(※ This code needs some additional environment variable)

## testing post mute

```javascript
import { expect } from "chai";

import Twitter from "../src/twitter";

describe("user context1.0a post mute", () => {
  it("should mute user", async () => {
    const client = new Twitter({
      consumer_key: process.env.TWITTER_CONSUMER_KEY,
      consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
      access_token_key: process.env.TWITTER_ACCESS_TOKEN,
      access_token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
    });

    const mute_user = process.env.MUTE_TARGET_USER_ID;
    const myid = process.env.YOUR_TWITTER_ID;
    const { data: result } = await client.post(`users/${myid}/muting`, {
      target_user_id: mute_user,
    });

    expect(result).to.not.be.empty;
    expect(result).to.include({ muting: true });
  });
});
```

Sorry for my awkward request.
I'm not used to use github.  
If I'm doing something wrong in this request, or if I've just coded `post()` method as wrong usage,
please discard it and fix this error.  
(Should I just post issue first?)
