### PR TITLE
Encode spaces in parameter values for oauth-1.0a

### DIFF
--- a/build/Credentials.d.ts
+++ b/build/Credentials.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-import { URL } from 'url';
 declare interface ApplicationConsumerCredentials {
     consumer_key: string;
     consumer_secret: string;
@@ -36,7 +34,7 @@ export default class Credentials {
     appAuth(): boolean;
     userAuth(): boolean;
     createBearerToken(): Promise<void>;
-    authorizationHeader(url: URL, request: {
+    authorizationHeader(url: string, request: {
         method: string;
         body?: object;
     }): Promise<string>;

--- a/build/Credentials.js
+++ b/build/Credentials.js
@@ -174,7 +174,7 @@ class Credentials {
             throw 'Access token should be defined for user authentication';
         }
         return this._oauth.toHeader(this._oauth.authorize({
-            url: url.toString(),
+            url: url,
             method: request.method,
             data: request.body,
         }, {

--- a/build/twitter.js
+++ b/build/twitter.js
@@ -26,6 +26,9 @@ function applyParameters(url, parameters, prefix) {
         }
     }
 }
+function getUrlString(url) {
+    return url.toString().replace(/\+/g, '%20');
+}
 class Twitter {
     constructor(args) {
         this.credentials = new Credentials_1.default(args);
@@ -33,9 +36,10 @@ class Twitter {
     async get(endpoint, parameters) {
         const url = new url_1.URL(`https://api.twitter.com/2/${endpoint}`);
         applyParameters(url, parameters);
-        const json = await node_fetch_1.default(url.toString(), {
+        const urlString = getUrlString(url);
+        const json = await node_fetch_1.default(urlString, {
             headers: {
-                Authorization: await this.credentials.authorizationHeader(url, {
+                Authorization: await this.credentials.authorizationHeader(urlString, {
                     method: 'GET',
                 }),
             },
@@ -49,11 +53,12 @@ class Twitter {
     async post(endpoint, body, parameters) {
         const url = new url_1.URL(`https://api.twitter.com/2/${endpoint}`);
         applyParameters(url, parameters);
-        const json = await node_fetch_1.default(url.toString(), {
+        const urlString = getUrlString(url);
+        const json = await node_fetch_1.default(urlString, {
             method: 'post',
             headers: {
                 'Content-Type': 'application/json',
-                Authorization: await this.credentials.authorizationHeader(url, {
+                Authorization: await this.credentials.authorizationHeader(urlString, {
                     method: 'POST',
                     body: body,
                 }),
@@ -69,10 +74,11 @@ class Twitter {
     async delete(endpoint, parameters) {
         const url = new url_1.URL(`https://api.twitter.com/2/${endpoint}`);
         applyParameters(url, parameters);
-        const json = await node_fetch_1.default(url.toString(), {
+        const urlString = getUrlString(url);
+        const json = await node_fetch_1.default(urlString, {
             method: 'delete',
             headers: {
-                Authorization: await this.credentials.authorizationHeader(url, {
+                Authorization: await this.credentials.authorizationHeader(urlString, {
                     method: 'DELETE',
                 }),
             },
@@ -88,10 +94,11 @@ class Twitter {
         return new TwitterStream_1.default(async () => {
             const url = new url_1.URL(`https://api.twitter.com/2/${endpoint}`);
             applyParameters(url, parameters);
-            return node_fetch_1.default(url.toString(), {
+            const urlString = getUrlString(url);
+            return node_fetch_1.default(urlString, {
                 signal: abortController.signal,
                 headers: {
-                    Authorization: await this.credentials.authorizationHeader(url, {
+                    Authorization: await this.credentials.authorizationHeader(urlString, {
                         method: 'GET',
                     }),
                 },

--- a/src/Credentials.ts
+++ b/src/Credentials.ts
@@ -298,7 +298,7 @@ export default class Credentials {
   }
 
   async authorizationHeader(
-    url: URL,
+    url: string,
     request: { method: string; body?: object }
   ): Promise<string> {
     if (this.appAuth()) {
@@ -315,7 +315,7 @@ export default class Credentials {
     return this._oauth.toHeader(
       this._oauth.authorize(
         {
-          url: url.toString(),
+          url: url,
           method: request.method,
           data: request.body,
         },

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -32,6 +32,13 @@ function applyParameters(
   }
 }
 
+function getUrlString(url: URL): string {
+  // make sure spaces query parameters are encoded as %20 and not +
+  // or else oauth signing fails since it uses decodeURIComponent and
+  // encodeURIComponent https://github.com/ddo/oauth-1.0a/issues/111
+  return url.toString().replace(/\+/g, '%20');
+}
+
 export default class Twitter {
   public credentials: Credentials;
 
@@ -46,9 +53,10 @@ export default class Twitter {
     const url = new URL(`https://api.twitter.com/2/${endpoint}`);
     applyParameters(url, parameters);
 
-    const json = await fetch(url.toString(), {
+    const urlString = getUrlString(url);
+    const json = await fetch(urlString, {
       headers: {
-        Authorization: await this.credentials.authorizationHeader(url, {
+        Authorization: await this.credentials.authorizationHeader(urlString, {
           method: 'GET',
         }),
       },
@@ -70,11 +78,12 @@ export default class Twitter {
     const url = new URL(`https://api.twitter.com/2/${endpoint}`);
     applyParameters(url, parameters);
 
-    const json = await fetch(url.toString(), {
+    const urlString = getUrlString(url);
+    const json = await fetch(urlString, {
       method: 'post',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: await this.credentials.authorizationHeader(url, {
+        Authorization: await this.credentials.authorizationHeader(urlString, {
           method: 'POST',
           body: body,
         }),
@@ -97,10 +106,11 @@ export default class Twitter {
     const url = new URL(`https://api.twitter.com/2/${endpoint}`);
     applyParameters(url, parameters);
 
-    const json = await fetch(url.toString(), {
+    const urlString = getUrlString(url);
+    const json = await fetch(urlString, {
       method: 'delete',
       headers: {
-        Authorization: await this.credentials.authorizationHeader(url, {
+        Authorization: await this.credentials.authorizationHeader(urlString, {
           method: 'DELETE',
         }),
       },
@@ -126,12 +136,16 @@ export default class Twitter {
         const url = new URL(`https://api.twitter.com/2/${endpoint}`);
         applyParameters(url, parameters);
 
-        return fetch(url.toString(), {
+        const urlString = getUrlString(url);
+        return fetch(urlString, {
           signal: abortController.signal,
           headers: {
-            Authorization: await this.credentials.authorizationHeader(url, {
-              method: 'GET',
-            }),
+            Authorization: await this.credentials.authorizationHeader(
+              urlString,
+              {
+                method: 'GET',
+              }
+            ),
           },
         });
       },

--- a/test/e2e/search.js
+++ b/test/e2e/search.js
@@ -68,5 +68,40 @@ if (!process.env.TWITTER_DISABLE_E2E) {
         result_count: tweets.length,
       });
     });
+
+    it('should search tweets with access tokens', async () => {
+      const client = new Twitter({
+        consumer_key: process.env.TWITTER_CONSUMER_KEY,
+        consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
+        access_token_key: process.env.TWITTER_ACCESS_TOKEN_KEY,
+        access_token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
+      });
+
+      // Recent Tweet Search API Reference: https://bit.ly/3jqFjKF
+      const { data: tweets, meta, errors } = await client.get(
+        'tweets/search/recent',
+        {
+          query: 'url:"https://medium.com" -is:retweet lang:en',
+          max_results: 10,
+          tweet: {
+            fields: [
+              'created_at',
+              'entities',
+              'in_reply_to_user_id',
+              'public_metrics',
+              'referenced_tweets',
+              'source',
+              'author_id',
+            ],
+          },
+        }
+      );
+
+      expect(errors).to.be.undefined;
+      expect(tweets).to.not.be.empty;
+      expect(meta).to.include({
+        result_count: tweets.length,
+      });
+    });
   });
 }


### PR DESCRIPTION
This commit fixes #90 by making sure that spaces in URLs are encoded using %20 instead +. While technically correct the underlying oauth-1.0a library will encode a + as %2B when signing, which causes an 401 Authentication error, because the URL that was signed was not the URL that was fetched.
    
The fix isn't particularly satisfying, but it does pass the tests except for `should stream data without any rules` which was already failing.
